### PR TITLE
NuGet Package Upgrades - March 2023

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
         # queries: security-extended,security-and-quality
 
         
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # Autobuild attempts to build any compiled languages (C / C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2

--- a/FirebotProxy.Api/FirebotProxy.Api.csproj
+++ b/FirebotProxy.Api/FirebotProxy.Api.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="OneOf" Version="3.0.223" />
         <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.6.2" />
         <PackageReference Include="Quartz.Plugins" Version="3.6.2" />
-        <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
+        <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
         <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>

--- a/FirebotProxy.Api/FirebotProxy.Api.csproj
+++ b/FirebotProxy.Api/FirebotProxy.Api.csproj
@@ -12,7 +12,6 @@
         <PackageReference Include="MediatR" Version="12.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.9" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-        <PackageReference Include="morelinq" Version="3.3.2" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="OneOf" Version="3.0.223" />
         <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.5.0" />

--- a/FirebotProxy.Api/FirebotProxy.Api.csproj
+++ b/FirebotProxy.Api/FirebotProxy.Api.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.6.2" />
         <PackageReference Include="Quartz.Plugins" Version="3.6.2" />
         <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
-        <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.1" />
+        <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>
 

--- a/FirebotProxy.Api/FirebotProxy.Api.csproj
+++ b/FirebotProxy.Api/FirebotProxy.Api.csproj
@@ -14,8 +14,8 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="OneOf" Version="3.0.223" />
-        <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.5.0" />
-        <PackageReference Include="Quartz.Plugins" Version="3.5.0" />
+        <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.6.2" />
+        <PackageReference Include="Quartz.Plugins" Version="3.6.2" />
         <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
         <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />

--- a/FirebotProxy.Api/FirebotProxy.Api.csproj
+++ b/FirebotProxy.Api/FirebotProxy.Api.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Mapster" Version="7.3.0" />
         <PackageReference Include="Mapster.DependencyInjection" Version="1.0.0" />
-        <PackageReference Include="MediatR" Version="11.0.0" />
+        <PackageReference Include="MediatR" Version="12.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.9" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
         <PackageReference Include="morelinq" Version="3.3.2" />

--- a/FirebotProxy.Api/FirebotProxy.Api.csproj
+++ b/FirebotProxy.Api/FirebotProxy.Api.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="MediatR" Version="12.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.9" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="OneOf" Version="3.0.223" />
         <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.5.0" />
         <PackageReference Include="Quartz.Plugins" Version="3.5.0" />

--- a/FirebotProxy.Api/FirebotProxy.Api.csproj
+++ b/FirebotProxy.Api/FirebotProxy.Api.csproj
@@ -18,7 +18,7 @@
         <PackageReference Include="Quartz.Plugins" Version="3.6.2" />
         <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
         <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/FirebotProxy.BackgroundWorker/FirebotProxy.BackgroundWorker.csproj
+++ b/FirebotProxy.BackgroundWorker/FirebotProxy.BackgroundWorker.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="Quartz.Plugins" Version="3.6.2" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-        <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.1" />
+        <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/FirebotProxy.BackgroundWorker/FirebotProxy.BackgroundWorker.csproj
+++ b/FirebotProxy.BackgroundWorker/FirebotProxy.BackgroundWorker.csproj
@@ -8,9 +8,9 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-        <PackageReference Include="Quartz" Version="3.5.0" />
-        <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.5.0" />
-        <PackageReference Include="Quartz.Plugins" Version="3.5.0" />
+        <PackageReference Include="Quartz" Version="3.6.2" />
+        <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.6.2" />
+        <PackageReference Include="Quartz.Plugins" Version="3.6.2" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
         <PackageReference Include="Serilog.Sinks.Seq" Version="5.2.1" />

--- a/FirebotProxy.BackgroundWorker/FirebotProxy.BackgroundWorker.csproj
+++ b/FirebotProxy.BackgroundWorker/FirebotProxy.BackgroundWorker.csproj
@@ -8,7 +8,6 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-        <PackageReference Include="morelinq" Version="3.3.2" />
         <PackageReference Include="Quartz" Version="3.5.0" />
         <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.5.0" />
         <PackageReference Include="Quartz.Plugins" Version="3.5.0" />

--- a/FirebotProxy.Data.Access.Tests/FirebotProxy.Data.Access.Tests.csproj
+++ b/FirebotProxy.Data.Access.Tests/FirebotProxy.Data.Access.Tests.csproj
@@ -12,7 +12,6 @@
       <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
       <PackageReference Include="Moq" Version="4.18.4" />
-      <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="NUnit" Version="3.13.3" />
     </ItemGroup>
 

--- a/FirebotProxy.Data.Access.Tests/FirebotProxy.Data.Access.Tests.csproj
+++ b/FirebotProxy.Data.Access.Tests/FirebotProxy.Data.Access.Tests.csproj
@@ -13,6 +13,7 @@
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
       <PackageReference Include="Moq" Version="4.18.4" />
       <PackageReference Include="NUnit" Version="3.13.3" />
+      <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/FirebotProxy.Data.Access.Tests/FirebotProxy.Data.Access.Tests.csproj
+++ b/FirebotProxy.Data.Access.Tests/FirebotProxy.Data.Access.Tests.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
       <PackageReference Include="FluentAssertions" Version="6.10.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
       <PackageReference Include="Moq" Version="4.18.2" />
       <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="NUnit" Version="3.13.3" />

--- a/FirebotProxy.Data.Access.Tests/FirebotProxy.Data.Access.Tests.csproj
+++ b/FirebotProxy.Data.Access.Tests/FirebotProxy.Data.Access.Tests.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentAssertions" Version="6.7.0" />
+      <PackageReference Include="FluentAssertions" Version="6.10.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
       <PackageReference Include="Moq" Version="4.18.2" />

--- a/FirebotProxy.Data.Access.Tests/FirebotProxy.Data.Access.Tests.csproj
+++ b/FirebotProxy.Data.Access.Tests/FirebotProxy.Data.Access.Tests.csproj
@@ -11,7 +11,7 @@
       <PackageReference Include="FluentAssertions" Version="6.10.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-      <PackageReference Include="Moq" Version="4.18.2" />
+      <PackageReference Include="Moq" Version="4.18.4" />
       <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="NUnit" Version="3.13.3" />
     </ItemGroup>

--- a/FirebotProxy.Data.Access/FirebotProxy.Data.Access.csproj
+++ b/FirebotProxy.Data.Access/FirebotProxy.Data.Access.csproj
@@ -13,7 +13,6 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.9" />
-      <PackageReference Include="morelinq" Version="3.3.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/FirebotProxy.Data.Entities/FirebotProxy.Data.Entities.csproj
+++ b/FirebotProxy.Data.Entities/FirebotProxy.Data.Entities.csproj
@@ -6,8 +6,4 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="morelinq" Version="3.3.2" />
-    </ItemGroup>
-
 </Project>

--- a/FirebotProxy.Domain.Tests/FakeHandlers/FakeRemoveExpiredChatMessagesCommandHandler.cs
+++ b/FirebotProxy.Domain.Tests/FakeHandlers/FakeRemoveExpiredChatMessagesCommandHandler.cs
@@ -12,13 +12,13 @@ public class FakeRemoveExpiredChatMessagesCommandHandler : IRequestHandler<Remov
         _shouldThrowException = shouldThrowException;
     }
 
-    public async Task<Unit> Handle(RemoveExpiredChatMessagesCommand request, CancellationToken cancellationToken)
+    public async Task Handle(RemoveExpiredChatMessagesCommand request, CancellationToken cancellationToken)
     {
         if (_shouldThrowException)
         {
             throw new Exception($"test exception message from {nameof(FakeRemoveMessagesByUsernameCommandHandler)}");
         }
 
-        return await Unit.Task;
+        await Unit.Task;
     }
 }

--- a/FirebotProxy.Domain.Tests/FakeHandlers/FakeRemoveMessagesByUsernameCommandHandler.cs
+++ b/FirebotProxy.Domain.Tests/FakeHandlers/FakeRemoveMessagesByUsernameCommandHandler.cs
@@ -12,13 +12,13 @@ public class FakeRemoveMessagesByUsernameCommandHandler : IRequestHandler<Remove
         _shouldThrowException = shouldThrowException;
     }
 
-    public async Task<Unit> Handle(RemoveMessagesByUsernameCommand request, CancellationToken cancellationToken)
+    public async Task Handle(RemoveMessagesByUsernameCommand request, CancellationToken cancellationToken)
     {
         if (_shouldThrowException)
         {
             throw new Exception($"test exception message from {nameof(FakeRemoveMessagesByUsernameCommandHandler)}");
         }
 
-        return await Unit.Task;
+        await Unit.Task;
     }
 }

--- a/FirebotProxy.Domain.Tests/FakeHandlers/FakeSaveChatMessageCommandHandler.cs
+++ b/FirebotProxy.Domain.Tests/FakeHandlers/FakeSaveChatMessageCommandHandler.cs
@@ -12,13 +12,13 @@ public class FakeSaveChatMessageCommandHandler : IRequestHandler<SaveChatMessage
         _shouldThrowException = shouldThrowException;
     }
 
-    public async Task<Unit> Handle(SaveChatMessageCommand request, CancellationToken cancellationToken)
+    public async Task Handle(SaveChatMessageCommand request, CancellationToken cancellationToken)
     {
         if (_shouldThrowException)
         {
             throw new Exception($"test exception message from {nameof(FakeSaveChatMessageCommandHandler)}");
         }
 
-        return await Unit.Task;
+        await Unit.Task;
     }
 }

--- a/FirebotProxy.Domain.Tests/FirebotProxy.Domain.Tests.csproj
+++ b/FirebotProxy.Domain.Tests/FirebotProxy.Domain.Tests.csproj
@@ -13,7 +13,6 @@
       <PackageReference Include="FluentAssertions" Version="6.10.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
       <PackageReference Include="Moq" Version="4.18.4" />
-      <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="NUnit" Version="3.13.3" />
     </ItemGroup>
 

--- a/FirebotProxy.Domain.Tests/FirebotProxy.Domain.Tests.csproj
+++ b/FirebotProxy.Domain.Tests/FirebotProxy.Domain.Tests.csproj
@@ -14,6 +14,7 @@
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
       <PackageReference Include="Moq" Version="4.18.4" />
       <PackageReference Include="NUnit" Version="3.13.3" />
+      <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/FirebotProxy.Domain.Tests/FirebotProxy.Domain.Tests.csproj
+++ b/FirebotProxy.Domain.Tests/FirebotProxy.Domain.Tests.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
       <PackageReference Include="AutoBogus" Version="2.13.1" />
       <PackageReference Include="Bogus" Version="34.0.2" />
-      <PackageReference Include="FluentAssertions" Version="6.7.0" />
+      <PackageReference Include="FluentAssertions" Version="6.10.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
       <PackageReference Include="Moq" Version="4.18.2" />
       <PackageReference Include="morelinq" Version="3.3.2" />

--- a/FirebotProxy.Domain.Tests/FirebotProxy.Domain.Tests.csproj
+++ b/FirebotProxy.Domain.Tests/FirebotProxy.Domain.Tests.csproj
@@ -11,7 +11,7 @@
       <PackageReference Include="AutoBogus" Version="2.13.1" />
       <PackageReference Include="Bogus" Version="34.0.2" />
       <PackageReference Include="FluentAssertions" Version="6.10.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
       <PackageReference Include="Moq" Version="4.18.2" />
       <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="NUnit" Version="3.13.3" />

--- a/FirebotProxy.Domain.Tests/FirebotProxy.Domain.Tests.csproj
+++ b/FirebotProxy.Domain.Tests/FirebotProxy.Domain.Tests.csproj
@@ -12,7 +12,7 @@
       <PackageReference Include="Bogus" Version="34.0.2" />
       <PackageReference Include="FluentAssertions" Version="6.10.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-      <PackageReference Include="Moq" Version="4.18.2" />
+      <PackageReference Include="Moq" Version="4.18.4" />
       <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="NUnit" Version="3.13.3" />
     </ItemGroup>

--- a/FirebotProxy.Domain/FirebotProxy.Domain.csproj
+++ b/FirebotProxy.Domain/FirebotProxy.Domain.csproj
@@ -10,7 +10,7 @@
       <PackageReference Include="Mapster" Version="7.3.0" />
       <PackageReference Include="FluentValidation" Version="11.5.1" />
       <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.1" />
-      <PackageReference Include="MediatR" Version="11.0.0" />
+      <PackageReference Include="MediatR" Version="12.0.1" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
       <PackageReference Include="morelinq" Version="3.3.2" />

--- a/FirebotProxy.Domain/FirebotProxy.Domain.csproj
+++ b/FirebotProxy.Domain/FirebotProxy.Domain.csproj
@@ -11,7 +11,6 @@
       <PackageReference Include="FluentValidation" Version="11.5.1" />
       <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.1" />
       <PackageReference Include="MediatR" Version="12.0.1" />
-      <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
       <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/FirebotProxy.Domain/FirebotProxy.Domain.csproj
+++ b/FirebotProxy.Domain/FirebotProxy.Domain.csproj
@@ -12,7 +12,6 @@
       <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.1" />
       <PackageReference Include="MediatR" Version="12.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-      <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="OneOf" Version="3.0.223" />
       <PackageReference Include="QuickChart" Version="2.3.0" />

--- a/FirebotProxy.Domain/FirebotProxy.Domain.csproj
+++ b/FirebotProxy.Domain/FirebotProxy.Domain.csproj
@@ -12,7 +12,7 @@
       <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.1" />
       <PackageReference Include="MediatR" Version="12.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="OneOf" Version="3.0.223" />
       <PackageReference Include="QuickChart" Version="2.3.0" />
     </ItemGroup>

--- a/FirebotProxy.Domain/FirebotProxy.Domain.csproj
+++ b/FirebotProxy.Domain/FirebotProxy.Domain.csproj
@@ -8,8 +8,8 @@
 
     <ItemGroup>
       <PackageReference Include="Mapster" Version="7.3.0" />
-      <PackageReference Include="FluentValidation" Version="11.2.2" />
-      <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.2.2" />
+      <PackageReference Include="FluentValidation" Version="11.5.1" />
+      <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.1" />
       <PackageReference Include="MediatR" Version="11.0.0" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/FirebotProxy.Domain/IoC/DomainInstaller.cs
+++ b/FirebotProxy.Domain/IoC/DomainInstaller.cs
@@ -1,17 +1,20 @@
 ﻿using System.Reflection;
 using FluentValidation;
-using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FirebotProxy.Domain.IoC;
 
 public class DomainInstaller
 {
-    public static readonly Assembly DomainProjectAssembly = typeof(DomainInstaller).Assembly;
+    private static readonly Assembly DomainProjectAssembly = typeof(DomainInstaller).Assembly;
 
     public static void Install(IServiceCollection services)
     {
-        services.AddMediatR(DomainProjectAssembly);
+        services.AddMediatR(x =>
+        {
+            x.RegisterServicesFromAssembly(DomainProjectAssembly);
+        });
+
         services.AddValidatorsFromAssembly(DomainProjectAssembly, ServiceLifetime.Singleton);
     }
 }

--- a/FirebotProxy.Extensions.Tests/FirebotProxy.Extensions.Tests.csproj
+++ b/FirebotProxy.Extensions.Tests/FirebotProxy.Extensions.Tests.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.10.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="morelinq" Version="3.3.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />

--- a/FirebotProxy.Extensions.Tests/FirebotProxy.Extensions.Tests.csproj
+++ b/FirebotProxy.Extensions.Tests/FirebotProxy.Extensions.Tests.csproj
@@ -12,8 +12,6 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/FirebotProxy.Extensions.Tests/FirebotProxy.Extensions.Tests.csproj
+++ b/FirebotProxy.Extensions.Tests/FirebotProxy.Extensions.Tests.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.7.0" />
+        <PackageReference Include="FluentAssertions" Version="6.10.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="Moq" Version="4.18.2" />
         <PackageReference Include="morelinq" Version="3.3.2" />

--- a/FirebotProxy.Extensions.Tests/FirebotProxy.Extensions.Tests.csproj
+++ b/FirebotProxy.Extensions.Tests/FirebotProxy.Extensions.Tests.csproj
@@ -11,7 +11,6 @@
         <PackageReference Include="FluentAssertions" Version="6.10.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="morelinq" Version="3.3.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
         <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />

--- a/FirebotProxy.Extensions.Tests/FirebotProxy.Extensions.Tests.csproj
+++ b/FirebotProxy.Extensions.Tests/FirebotProxy.Extensions.Tests.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/FirebotProxy.Extensions.Tests/FirebotProxy.Extensions.Tests.csproj
+++ b/FirebotProxy.Extensions.Tests/FirebotProxy.Extensions.Tests.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="6.10.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="Moq" Version="4.18.2" />
+        <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="morelinq" Version="3.3.2" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/FirebotProxy.Extensions.Tests/FirebotProxy.Extensions.Tests.csproj
+++ b/FirebotProxy.Extensions.Tests/FirebotProxy.Extensions.Tests.csproj
@@ -8,7 +8,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="3.1.2" />
         <PackageReference Include="FluentAssertions" Version="6.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="Moq" Version="4.18.2" />

--- a/FirebotProxy.Extensions/FirebotProxy.Extensions.csproj
+++ b/FirebotProxy.Extensions/FirebotProxy.Extensions.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
-      <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.5.0" />
+      <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.6.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/FirebotProxy.Extensions/FirebotProxy.Extensions.csproj
+++ b/FirebotProxy.Extensions/FirebotProxy.Extensions.csproj
@@ -8,7 +8,6 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
-      <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.5.0" />
     </ItemGroup>
 

--- a/FirebotProxy.Helpers.Tests/FirebotProxy.Helpers.Tests.csproj
+++ b/FirebotProxy.Helpers.Tests/FirebotProxy.Helpers.Tests.csproj
@@ -11,7 +11,6 @@
       <PackageReference Include="FluentAssertions" Version="6.10.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
       <PackageReference Include="Moq" Version="4.18.4" />
-      <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="NUnit" Version="3.13.3" />
     </ItemGroup>
 

--- a/FirebotProxy.Helpers.Tests/FirebotProxy.Helpers.Tests.csproj
+++ b/FirebotProxy.Helpers.Tests/FirebotProxy.Helpers.Tests.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
       <PackageReference Include="FluentAssertions" Version="6.10.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-      <PackageReference Include="Moq" Version="4.18.2" />
+      <PackageReference Include="Moq" Version="4.18.4" />
       <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="NUnit" Version="3.13.3" />
     </ItemGroup>

--- a/FirebotProxy.Helpers.Tests/FirebotProxy.Helpers.Tests.csproj
+++ b/FirebotProxy.Helpers.Tests/FirebotProxy.Helpers.Tests.csproj
@@ -12,6 +12,7 @@
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
       <PackageReference Include="Moq" Version="4.18.4" />
       <PackageReference Include="NUnit" Version="3.13.3" />
+      <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/FirebotProxy.Helpers.Tests/FirebotProxy.Helpers.Tests.csproj
+++ b/FirebotProxy.Helpers.Tests/FirebotProxy.Helpers.Tests.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="FluentAssertions" Version="6.10.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
       <PackageReference Include="Moq" Version="4.18.2" />
       <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="NUnit" Version="3.13.3" />

--- a/FirebotProxy.Helpers.Tests/FirebotProxy.Helpers.Tests.csproj
+++ b/FirebotProxy.Helpers.Tests/FirebotProxy.Helpers.Tests.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentAssertions" Version="6.7.0" />
+      <PackageReference Include="FluentAssertions" Version="6.10.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
       <PackageReference Include="Moq" Version="4.18.2" />
       <PackageReference Include="morelinq" Version="3.3.2" />

--- a/FirebotProxy.Helpers/FirebotProxy.Helpers.csproj
+++ b/FirebotProxy.Helpers/FirebotProxy.Helpers.csproj
@@ -6,8 +6,4 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="morelinq" Version="3.3.2" />
-    </ItemGroup>
-
 </Project>

--- a/FirebotProxy.Infrastructure.Tests/FirebotProxy.Infrastructure.Tests.csproj
+++ b/FirebotProxy.Infrastructure.Tests/FirebotProxy.Infrastructure.Tests.csproj
@@ -11,7 +11,6 @@
       <PackageReference Include="FluentAssertions" Version="6.10.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
       <PackageReference Include="Moq" Version="4.18.4" />
-      <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="NUnit" Version="3.13.3" />
     </ItemGroup>
 

--- a/FirebotProxy.Infrastructure.Tests/FirebotProxy.Infrastructure.Tests.csproj
+++ b/FirebotProxy.Infrastructure.Tests/FirebotProxy.Infrastructure.Tests.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
       <PackageReference Include="FluentAssertions" Version="6.10.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-      <PackageReference Include="Moq" Version="4.18.2" />
+      <PackageReference Include="Moq" Version="4.18.4" />
       <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="NUnit" Version="3.13.3" />
     </ItemGroup>

--- a/FirebotProxy.Infrastructure.Tests/FirebotProxy.Infrastructure.Tests.csproj
+++ b/FirebotProxy.Infrastructure.Tests/FirebotProxy.Infrastructure.Tests.csproj
@@ -12,6 +12,7 @@
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
       <PackageReference Include="Moq" Version="4.18.4" />
       <PackageReference Include="NUnit" Version="3.13.3" />
+      <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/FirebotProxy.Infrastructure.Tests/FirebotProxy.Infrastructure.Tests.csproj
+++ b/FirebotProxy.Infrastructure.Tests/FirebotProxy.Infrastructure.Tests.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="FluentAssertions" Version="6.10.0" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
       <PackageReference Include="Moq" Version="4.18.2" />
       <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="NUnit" Version="3.13.3" />

--- a/FirebotProxy.Infrastructure.Tests/FirebotProxy.Infrastructure.Tests.csproj
+++ b/FirebotProxy.Infrastructure.Tests/FirebotProxy.Infrastructure.Tests.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentAssertions" Version="6.7.0" />
+      <PackageReference Include="FluentAssertions" Version="6.10.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
       <PackageReference Include="Moq" Version="4.18.2" />
       <PackageReference Include="morelinq" Version="3.3.2" />

--- a/FirebotProxy.Infrastructure/Adapters/RemoveExpiredChatMessagesCommandHandler.cs
+++ b/FirebotProxy.Infrastructure/Adapters/RemoveExpiredChatMessagesCommandHandler.cs
@@ -20,7 +20,7 @@ internal class RemoveExpiredChatMessagesCommandHandler : IRequestHandler<RemoveE
         _context = context;
     }
 
-    public async Task<Unit> Handle(RemoveExpiredChatMessagesCommand request, CancellationToken cancellationToken)
+    public async Task Handle(RemoveExpiredChatMessagesCommand request, CancellationToken cancellationToken)
     {
         var strategy = _context.Database.CreateExecutionStrategy();
 
@@ -48,7 +48,5 @@ internal class RemoveExpiredChatMessagesCommandHandler : IRequestHandler<RemoveE
                 throw;
             }
         });
-
-        return Unit.Value;
     }
 }

--- a/FirebotProxy.Infrastructure/Adapters/RemoveMessagesByUsernameCommandHandler.cs
+++ b/FirebotProxy.Infrastructure/Adapters/RemoveMessagesByUsernameCommandHandler.cs
@@ -20,7 +20,7 @@ internal class RemoveMessagesByUsernameCommandHandler : IRequestHandler<RemoveMe
         _context = context;
     }
 
-    public async Task<Unit> Handle(RemoveMessagesByUsernameCommand request, CancellationToken cancellationToken)
+    public async Task Handle(RemoveMessagesByUsernameCommand request, CancellationToken cancellationToken)
     {
         var strategy = _context.Database.CreateExecutionStrategy();
 
@@ -47,7 +47,5 @@ internal class RemoveMessagesByUsernameCommandHandler : IRequestHandler<RemoveMe
                 throw;
             }
         });
-
-        return Unit.Value;
     }
 }

--- a/FirebotProxy.Infrastructure/Adapters/SaveChatMessageCommandHandler.cs
+++ b/FirebotProxy.Infrastructure/Adapters/SaveChatMessageCommandHandler.cs
@@ -20,7 +20,7 @@ internal class SaveChatMessageCommandHandler : IRequestHandler<SaveChatMessageCo
         _context = context;
     }
 
-    public async Task<Unit> Handle(SaveChatMessageCommand request, CancellationToken cancellationToken)
+    public async Task Handle(SaveChatMessageCommand request, CancellationToken cancellationToken)
     {
         var strategy = _context.Database.CreateExecutionStrategy();
 
@@ -42,7 +42,5 @@ internal class SaveChatMessageCommandHandler : IRequestHandler<SaveChatMessageCo
                 throw;
             }
         });
-
-        return Unit.Value;
     }
 }

--- a/FirebotProxy.Infrastructure/FirebotProxy.Infrastructure.csproj
+++ b/FirebotProxy.Infrastructure/FirebotProxy.Infrastructure.csproj
@@ -10,7 +10,7 @@
       <PackageReference Include="MediatR" Version="12.0.1" />
       <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="OneOf" Version="3.0.223" />
       <PackageReference Include="Refit" Version="6.3.2" />
       <PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />

--- a/FirebotProxy.Infrastructure/FirebotProxy.Infrastructure.csproj
+++ b/FirebotProxy.Infrastructure/FirebotProxy.Infrastructure.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="MediatR" Version="11.0.0" />
+      <PackageReference Include="MediatR" Version="12.0.1" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
       <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />

--- a/FirebotProxy.Infrastructure/FirebotProxy.Infrastructure.csproj
+++ b/FirebotProxy.Infrastructure/FirebotProxy.Infrastructure.csproj
@@ -10,7 +10,6 @@
       <PackageReference Include="MediatR" Version="12.0.1" />
       <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-      <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="OneOf" Version="3.0.223" />
       <PackageReference Include="Refit" Version="6.3.2" />

--- a/FirebotProxy.Infrastructure/FirebotProxy.Infrastructure.csproj
+++ b/FirebotProxy.Infrastructure/FirebotProxy.Infrastructure.csproj
@@ -8,7 +8,6 @@
 
     <ItemGroup>
       <PackageReference Include="MediatR" Version="12.0.1" />
-      <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
       <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
       <PackageReference Include="morelinq" Version="3.3.2" />

--- a/FirebotProxy.Infrastructure/IoC/InfrastructureInstaller.cs
+++ b/FirebotProxy.Infrastructure/IoC/InfrastructureInstaller.cs
@@ -14,7 +14,10 @@ public class InfrastructureInstaller
     {
         AddInfrastructureServices(services);
 
-        services.AddMediatR(InfrastructureProjectAssembly);
+        services.AddMediatR(x =>
+        {
+            x.RegisterServicesFromAssembly(InfrastructureProjectAssembly);
+        });
     }
 
     private static void AddInfrastructureServices(IServiceCollection services)

--- a/FirebotProxy.Models/FirebotProxy.Models.csproj
+++ b/FirebotProxy.Models/FirebotProxy.Models.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Quartz" Version="3.5.0" />
-      <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.5.0" />
+      <PackageReference Include="Quartz" Version="3.6.2" />
+      <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.6.2" />
     </ItemGroup>
 
 </Project>

--- a/FirebotProxy.Models/FirebotProxy.Models.csproj
+++ b/FirebotProxy.Models/FirebotProxy.Models.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="Quartz" Version="3.5.0" />
       <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.5.0" />
     </ItemGroup>

--- a/FirebotProxy.SecondaryPorts/FirebotProxy.SecondaryPorts.csproj
+++ b/FirebotProxy.SecondaryPorts/FirebotProxy.SecondaryPorts.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="MediatR" Version="11.0.0" />
+      <PackageReference Include="MediatR" Version="12.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
       <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/FirebotProxy.SecondaryPorts/FirebotProxy.SecondaryPorts.csproj
+++ b/FirebotProxy.SecondaryPorts/FirebotProxy.SecondaryPorts.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
       <PackageReference Include="MediatR" Version="12.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="OneOf" Version="3.0.223" />
       <PackageReference Include="Refit" Version="6.3.2" />
     </ItemGroup>

--- a/FirebotProxy.SecondaryPorts/FirebotProxy.SecondaryPorts.csproj
+++ b/FirebotProxy.SecondaryPorts/FirebotProxy.SecondaryPorts.csproj
@@ -9,7 +9,6 @@
     <ItemGroup>
       <PackageReference Include="MediatR" Version="12.0.1" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-      <PackageReference Include="morelinq" Version="3.3.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="OneOf" Version="3.0.223" />
       <PackageReference Include="Refit" Version="6.3.2" />

--- a/FirebotProxy.SecondaryPorts/RemoveExpiredChatMessages/RemoveExpiredChatMessagesCommand.cs
+++ b/FirebotProxy.SecondaryPorts/RemoveExpiredChatMessages/RemoveExpiredChatMessagesCommand.cs
@@ -2,7 +2,7 @@
 
 namespace FirebotProxy.SecondaryPorts.RemoveExpiredChatMessages;
 
-public class RemoveExpiredChatMessagesCommand : IRequest<Unit>
+public class RemoveExpiredChatMessagesCommand : IRequest
 {
     public DateTime Cutoff { get; set; }
 }

--- a/FirebotProxy.SecondaryPorts/RemoveMessagesByUsername/RemoveMessagesByUsernameCommand.cs
+++ b/FirebotProxy.SecondaryPorts/RemoveMessagesByUsername/RemoveMessagesByUsernameCommand.cs
@@ -2,7 +2,7 @@
 
 namespace FirebotProxy.SecondaryPorts.RemoveMessagesByUsername;
 
-public class RemoveMessagesByUsernameCommand : IRequest<Unit>
+public class RemoveMessagesByUsernameCommand : IRequest
 {
     public string SenderUsername { get; set; } = null!;
 }

--- a/FirebotProxy.SecondaryPorts/SaveChatMessage/SaveChatMessageCommand.cs
+++ b/FirebotProxy.SecondaryPorts/SaveChatMessage/SaveChatMessageCommand.cs
@@ -3,7 +3,7 @@ using MediatR;
 
 namespace FirebotProxy.SecondaryPorts.SaveChatMessage;
 
-public class SaveChatMessageCommand : IRequest<Unit>
+public class SaveChatMessageCommand : IRequest
 {
     public ChatMessage ChatMessage { get; set; } = null!;
 }

--- a/FirebotProxy.Seeding/FirebotProxy.Seeding.csproj
+++ b/FirebotProxy.Seeding/FirebotProxy.Seeding.csproj
@@ -13,7 +13,7 @@
       <PackageReference Include="Bogus" Version="34.0.2" />
       <PackageReference Include="CommandLineParser" Version="2.9.1" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-      <PackageReference Include="morelinq" Version="3.3.2" />
+      <PackageReference Include="morelinq" Version="3.4.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/FirebotProxy.TestBase/FirebotProxy.TestBase.csproj
+++ b/FirebotProxy.TestBase/FirebotProxy.TestBase.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="FluentValidation" Version="11.5.1" />
-      <PackageReference Include="MediatR" Version="11.0.0" />
+      <PackageReference Include="MediatR" Version="12.0.1" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/FirebotProxy.TestBase/FirebotProxy.TestBase.csproj
+++ b/FirebotProxy.TestBase/FirebotProxy.TestBase.csproj
@@ -13,7 +13,6 @@
       <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-      <PackageReference Include="morelinq" Version="3.3.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/FirebotProxy.TestBase/FirebotProxy.TestBase.csproj
+++ b/FirebotProxy.TestBase/FirebotProxy.TestBase.csproj
@@ -13,6 +13,7 @@
       <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+      <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/FirebotProxy.TestBase/FirebotProxy.TestBase.csproj
+++ b/FirebotProxy.TestBase/FirebotProxy.TestBase.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentValidation" Version="11.2.2" />
+      <PackageReference Include="FluentValidation" Version="11.5.1" />
       <PackageReference Include="MediatR" Version="11.0.0" />
       <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />

--- a/FirebotProxy.TestBase/FirebotProxy.TestBase.csproj
+++ b/FirebotProxy.TestBase/FirebotProxy.TestBase.csproj
@@ -10,7 +10,6 @@
     <ItemGroup>
       <PackageReference Include="FluentValidation" Version="11.5.1" />
       <PackageReference Include="MediatR" Version="12.0.1" />
-      <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
       <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.9" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />

--- a/FirebotProxy.TestBase/MediatRFactory.cs
+++ b/FirebotProxy.TestBase/MediatRFactory.cs
@@ -15,12 +15,21 @@ public class MediatRFactory
 
     public MediatRFactory(Assembly assembly) : this()
     {
-        _services.AddMediatR(assembly);
+        _services.AddMediatR(x =>
+        {
+            x.RegisterServicesFromAssembly(assembly);
+        });
     }
 
     public MediatRFactory AddSingletonHandler<T, T2>(IRequestHandler<T, T2> instance) where T : class, IRequest<T2>
     {
-        _services.AddTransient((s) => instance);
+        _services.AddTransient(_ => instance);
+        return this;
+    }
+
+    public MediatRFactory AddSingletonHandler<T>(IRequestHandler<T> instance) where T : class, IRequest
+    {
+        _services.AddTransient(_ => instance);
         return this;
     }
 
@@ -32,7 +41,7 @@ public class MediatRFactory
 
     public MediatRFactory AddTransientType<T>(T instance) where T : class
     {
-        _services.AddTransient((s) => instance);
+        _services.AddTransient(_ => instance);
         return this;
     }
 

--- a/FirebotProxy.Validation/FirebotProxy.Validation.csproj
+++ b/FirebotProxy.Validation/FirebotProxy.Validation.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="FluentValidation" Version="11.2.2" />
+      <PackageReference Include="FluentValidation" Version="11.5.1" />
       <PackageReference Include="morelinq" Version="3.3.2" />
     </ItemGroup>
 

--- a/FirebotProxy.Validation/FirebotProxy.Validation.csproj
+++ b/FirebotProxy.Validation/FirebotProxy.Validation.csproj
@@ -8,7 +8,6 @@
 
     <ItemGroup>
       <PackageReference Include="FluentValidation" Version="11.5.1" />
-      <PackageReference Include="morelinq" Version="3.3.2" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
**tl;dr**
Upgrades a series of third-party NuGet packages that are used throughout the solution. These changes don't introduce breaking changes for users.

**Upgrade Notes**
Some code modifications had to be made when upgrading MediatR from version 11 to 12: the definition of `IRequest` has changed such that you cannot have a request type that implements `IRequest<Unit>` - this is now simply `IRequest`. As such, the various handlers, fake handlers, and installers have been updated to reflect this change.